### PR TITLE
fix: 修复 nacos.inetutils.preferred-networks 和nacos.inetutils.ignored-interfaces 参数不起作用的问题,nacos默认从 conf/application.properties 文件获取

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,8 @@ ENV MODE="cluster" \
     JVM_MMS="320m" \
     NACOS_DEBUG="n" \
     TOMCAT_ACCESSLOG_ENABLED="false" \
-    TIME_ZONE="Asia/Shanghai"
+    TIME_ZONE="Asia/Shanghai" \
+    NACOS_SERVER_PORT=8848
 
 ARG NACOS_VERSION=1.1.3
 
@@ -50,5 +51,5 @@ RUN mkdir -p logs \
 	&& ln -sf /dev/stderr start.out
 RUN chmod +x bin/docker-startup.sh
 
-EXPOSE 8848
+EXPOSE $NACOS_SERVER_PORT
 ENTRYPOINT ["bin/docker-startup.sh"]

--- a/build/bin/docker-startup.sh
+++ b/build/bin/docker-startup.sh
@@ -62,7 +62,7 @@ fi
 if [[ ! -z "${USE_ONLY_SITE_INTERFACES}" ]]; then
     JAVA_OPT="${JAVA_OPT} -Dnacos.inetutils.use-only-site-local-interfaces=${USE_ONLY_SITE_INTERFACES}"
 fi
-idx=0
+
 if [[ ! -z "${PREFERRED_NETWORKS}" ]]; then
     idx=0
     #JAVA_OPT="${JAVA_OPT} -Dnacos.inetutils.preferred-networks=${PREFERRED_NETWORKS}"
@@ -80,6 +80,7 @@ if [[ ! -z "${IGNORED_INTERFACES}" ]]; then
      idx=$(( $idx + 1 ))
     done
 fi
+
 
 if [[ "${PREFER_HOST_MODE}" == "hostname" ]]; then
     JAVA_OPT="${JAVA_OPT} -Dnacos.preferHostnameOverIp=true"

--- a/build/bin/docker-startup.sh
+++ b/build/bin/docker-startup.sh
@@ -62,13 +62,23 @@ fi
 if [[ ! -z "${USE_ONLY_SITE_INTERFACES}" ]]; then
     JAVA_OPT="${JAVA_OPT} -Dnacos.inetutils.use-only-site-local-interfaces=${USE_ONLY_SITE_INTERFACES}"
 fi
-
+idx=0
 if [[ ! -z "${PREFERRED_NETWORKS}" ]]; then
-    JAVA_OPT="${JAVA_OPT} -Dnacos.inetutils.preferred-networks=${PREFERRED_NETWORKS}"
+    idx=0
+    #JAVA_OPT="${JAVA_OPT} -Dnacos.inetutils.preferred-networks=${PREFERRED_NETWORKS}"
+    echo ${PREFERRED_NETWORKS} | sed -n 1'p' | tr ',' '\n' | while read ip; do
+     echo "nacos.inetutils.preferred-networks[${idx}]=$ip" >> ${BASE_DIR}/conf/application.properties
+     idx=$(( $idx + 1 ))
+    done
 fi
 
 if [[ ! -z "${IGNORED_INTERFACES}" ]]; then
-    JAVA_OPT="${JAVA_OPT} -Dnacos.inetutils.ignored-interfaces=${IGNORED_INTERFACES}"
+#    JAVA_OPT="${JAVA_OPT} -Dnacos.inetutils.ignored-interfaces=${IGNORED_INTERFACES}"
+    idx=0
+    echo ${IGNORED_INTERFACES} | sed -n 1'p' | tr ',' '\n' | while read ip; do
+     echo "nacos.inetutils.ignored-interfaces[${idx}]=$ip" >> ${BASE_DIR}/conf/application.properties
+     idx=$(( $idx + 1 ))
+    done
 fi
 
 if [[ "${PREFER_HOST_MODE}" == "hostname" ]]; then


### PR DESCRIPTION
fix: 修复 nacos.inetutils.preferred-networks 和nacos.inetutils.ignored-interfaces 参数不起作用的问题,nacos默认从 conf/application.properties 文件获取