### PR TITLE
增加mysql ssl支持，默认为false

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Run the following command：
 | MYSQL_SERVICE_DB_NAME | mysql  database name |  |
 | MYSQL_SERVICE_USER | username of  database |  |
 | MYSQL_SERVICE_PASSWORD | password of  database |  |
+| MYSQL_SSL_ENABLE | use ssl | default : false |
 | ~~MYSQL_MASTER_SERVICE_HOST~~     | The **latest** version of the image removes this attribute, using MYSQL_SERVICE_HOST |                                        |
 | ~~MYSQL_MASTER_SERVICE_PORT~~     | The **latest** version of the image removes this attribute, using MYSQL_SERVICE_PORT | default : **3306**                     |
 | ~~MYSQL_MASTER_SERVICE_DB_NAME~~  | The **latest** version of the image removes this attribute, using MYSQL_SERVICE_DB_NAME |                                        |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -99,6 +99,7 @@
 | MYSQL_SERVICE_DB_NAME             | mysql  database name                                         |                                     |
 | MYSQL_SERVICE_USER                | username of  database                                        |                                     |
 | MYSQL_SERVICE_PASSWORD            | password of  database                                        |                                     |
+| MYSQL_SSL_ENABLE | use ssl | 默认 : false |
 | ~~MYSQL_MASTER_SERVICE_HOST~~     | **latest(目前latest 是1.1.4)以后**版本镜像移除, 使用 MYSQL_SERVICE_HOST |                                     |
 | ~~MYSQL_MASTER_SERVICE_PORT~~     | **latest(目前latest 是1.1.4)以后**版本镜像移除, 使用 using MYSQL_SERVICE_PORT | 默认 : **3306**                  |
 | ~~MYSQL_MASTER_SERVICE_DB_NAME~~  | **latest(目前latest 是1.1.4)以后**版本镜像移除, 使用 MYSQL_SERVICE_DB_NAME |                                     |

--- a/build/conf/application.properties
+++ b/build/conf/application.properties
@@ -8,8 +8,8 @@ nacos.cmdb.eventTaskInterval=10
 nacos.cmdb.labelTaskInterval=300
 nacos.cmdb.loadDataAtStart=false
 db.num=${MYSQL_DATABASE_NUM:1}
-db.url.0=jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT:3306}/${MYSQL_SERVICE_DB_NAME}?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
-db.url.1=jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT:3306}/${MYSQL_SERVICE_DB_NAME}?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true
+db.url.0=jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT:3306}/${MYSQL_SERVICE_DB_NAME}?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useSSL=${MYSQL_SSL_ENABLE:false}
+db.url.1=jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT:3306}/${MYSQL_SERVICE_DB_NAME}?characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useSSL=${MYSQL_SSL_ENABLE:false}
 db.user=${MYSQL_SERVICE_USER}
 db.password=${MYSQL_SERVICE_PASSWORD}
 ### The auth system to use, currently only 'nacos' is supported:


### PR DESCRIPTION
自建数据库一直报 No DataSource set [#151](https://github.com/nacos-group/nacos-k8s/issues/151)

添加了MYSQL_SSL_ENABLE的可选参数，默认为false