### PR TITLE
完善使用说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Run the following command：
   cd nacos-docker
   ```
 
+* Export NACOS_VERSION
+
+  ```powershell
+  # Nacos Verison you want install
+  export NACOS_VERSION=2.0.0-bugfix
+  ```
 
 * Standalone Derby
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -37,6 +37,12 @@
   cd nacos-docker
   ```
 
+* Export NACOS_VERSION
+
+  ```powershell
+  # Nacos Verison you want install
+  export NACOS_VERSION=2.0.0-bugfix
+  ```
 
 * Standalone Derby
 


### PR DESCRIPTION
docker yml脚本使用了${NACOS_VERSION}环境变量作为nacos镜像tag值，运行时此变量为空会报错，完善了这部分的说明。