### PR TITLE
resolve password include special  character ','

### DIFF
--- a/build/conf/application.properties
+++ b/build/conf/application.properties
@@ -10,8 +10,8 @@ nacos.cmdb.loadDataAtStart=false
 db.num=${MYSQL_DATABASE_NUM:1}
 db.url.0=jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT:3306}/${MYSQL_SERVICE_DB_NAME}?${MYSQL_SERVICE_DB_PARAM:characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useSSL=false}
 db.url.1=jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT:3306}/${MYSQL_SERVICE_DB_NAME}?${MYSQL_SERVICE_DB_PARAM:characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useSSL=false}
-db.user=${MYSQL_SERVICE_USER}
-db.password=${MYSQL_SERVICE_PASSWORD}
+db.user.0=${MYSQL_SERVICE_USER}
+db.password.0=${MYSQL_SERVICE_PASSWORD}
 ### The auth system to use, currently only 'nacos' is supported:
 nacos.core.auth.system.type=${NACOS_AUTH_SYSTEM_TYPE:nacos}
 


### PR DESCRIPTION
如果密码中包含特殊字符 `,` 时会导致被解析成两个密码而无法连接数据库，如这个  [ISSUE-#4179](https://github.com/alibaba/nacos/issues/4179) 提到的问题，
既然已经[移除数据库主从镜像配置](https://github.com/nacos-group/nacos-docker/wiki/%E7%A7%BB%E9%99%A4%E6%95%B0%E6%8D%AE%E5%BA%93%E4%B8%BB%E4%BB%8E%E9%95%9C%E5%83%8F%E9%85%8D%E7%BD%AE)，所以建议不如参考这个 [PR](https://github.com/alibaba/nacos/pull/4186) 先将 application.properties 中的 mysql 配置修改为 
`db.user.0=xx `
`db.password.0=xx`