### PR TITLE
fix cluster.conf

### DIFF
--- a/build/bin/docker-startup.sh
+++ b/build/bin/docker-startup.sh
@@ -17,7 +17,7 @@ export CUSTOM_SEARCH_LOCATIONS=file:${BASE_DIR}/conf/
 export MEMBER_LIST=""
 PLUGINS_DIR="/home/nacos/plugins/peer-finder"
 function print_servers() {
-  if [[ ! -d "${PLUGINS_DIR}" ]]; then
+  if [[ ! -f "${CLUSTER_CONF}" ]]; then
     echo "" >"$CLUSTER_CONF"
     for server in ${NACOS_SERVERS}; do
       echo "$server" >>"$CLUSTER_CONF"


### PR DESCRIPTION
修复目录存在，文件不存在的情况，在部署nacos-k8s，[配置文件](https://github.com/nacos-group/nacos-k8s/blob/master/deploy/nacos/nacos-pvc-nfs.yaml)，其中定义了/home/nacos/plugins/peer-finder，但是启动后，cluster.conf并没创建，导致无法启动