### PR TITLE
Fix typo of default version of nacos jar

### DIFF
--- a/build/Dockerfile.Slim
+++ b/build/Dockerfile.Slim
@@ -1,6 +1,6 @@
 FROM amd64/buildpack-deps:buster-curl as installer
 
-ARG NACOS_VERSION=2.1.2常德
+ARG NACOS_VERSION=2.1.2
 ARG HOT_FIX_FLAG=""
 
 RUN set -x \


### PR DESCRIPTION
Seems the typo of commit, fixed.