### PR TITLE
Update standalone-derby.yaml

### DIFF
--- a/example/standalone-derby.yaml
+++ b/example/standalone-derby.yaml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   nacos:
-    image: nacos/nacos-server:v${NACOS_VERSION}
+    image: nacos/nacos-server:${NACOS_VERSION}
     container_name: nacos-standalone
     environment:
       - PREFER_HOST_MODE=hostname


### PR DESCRIPTION
fix: Error response from daemon: manifest for nacos/nacos-server:vv2.2.0 not found: manifest unknown: manifest unknown