### PR TITLE
Fix empty value

### DIFF
--- a/build/conf/application.properties
+++ b/build/conf/application.properties
@@ -5,6 +5,7 @@ server.port=${NACOS_APPLICATION_PORT:8848}
 server.tomcat.accesslog.max-days=30
 server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %{User-Agent}i %{Request-Source}i
 server.tomcat.accesslog.enabled=${TOMCAT_ACCESSLOG_ENABLED:false}
+server.error.include-message=ALWAYS
 # default current work dir
 server.tomcat.basedir=file:.
 #*************** Config Module Related Configurations ***************#

--- a/build/conf/application.properties
+++ b/build/conf/application.properties
@@ -25,12 +25,12 @@ nacos.core.auth.system.type=${NACOS_AUTH_SYSTEM_TYPE:nacos}
 ### The token expiration in seconds:
 nacos.core.auth.plugin.nacos.token.expire.seconds=${NACOS_AUTH_TOKEN_EXPIRE_SECONDS:18000}
 ### The default token:
-nacos.core.auth.plugin.nacos.token.secret.key=${NACOS_AUTH_TOKEN}
+nacos.core.auth.plugin.nacos.token.secret.key=${NACOS_AUTH_TOKEN:}
 ### Turn on/off caching of auth information. By turning on this switch, the update of auth information would have a 15 seconds delay.
 nacos.core.auth.caching.enabled=${NACOS_AUTH_CACHE_ENABLE:false}
 nacos.core.auth.enable.userAgentAuthWhite=${NACOS_AUTH_USER_AGENT_AUTH_WHITE_ENABLE:false}
-nacos.core.auth.server.identity.key=${NACOS_AUTH_IDENTITY_KEY}
-nacos.core.auth.server.identity.value=${NACOS_AUTH_IDENTITY_VALUE}
+nacos.core.auth.server.identity.key=${NACOS_AUTH_IDENTITY_KEY:}
+nacos.core.auth.server.identity.value=${NACOS_AUTH_IDENTITY_VALUE:}
 ## spring security config
 ### turn off security
 nacos.security.ignore.urls=${NACOS_SECURITY_IGNORE_URLS:/,/error,/**/*.css,/**/*.js,/**/*.html,/**/*.map,/**/*.svg,/**/*.png,/**/*.ico,/console-fe/public/**,/v1/auth/**,/v1/console/health/**,/actuator/**,/v1/console/server/**}


### PR DESCRIPTION
In the application file, when using the environment variable expression, not adding the default null expression causes the program to start without an error because of this value

Incorrect
``` properties
nacos.core.auth.plugin.nacos.token.secret.key=${NACOS_AUTH_TOKEN}
nacos.core.auth.server.identity.key=${NACOS_AUTH_IDENTITY_KEY}
nacos.core.auth.server.identity.value=${NACOS_AUTH_IDENTITY_VALUE}
```

correct
``` properties
nacos.core.auth.plugin.nacos.token.secret.key=${NACOS_AUTH_TOKEN:}
nacos.core.auth.server.identity.key=${NACOS_AUTH_IDENTITY_KEY:}
nacos.core.auth.server.identity.value=${NACOS_AUTH_IDENTITY_VALUE:}
```

