### PR TITLE
Add prometheus metrics exposure variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ docker-compose -f example/custom-application-config.yaml up -d
 
 ## Nacos + Grafana + Prometheus
 
+| name                                     | description                                                                                                                       | option                                                                                                                                                                                |
+|------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|PROM_METRICS_ENABLE                        |  Metrics for the prometheus.management endpoint web exposure include all. |default : false            |
+
+
 Usage reference：[Nacos monitor-guide](https://nacos.io/zh-cn/docs/monitor-guide.html)
 
 **Note**:  When Grafana creates a new data source, the data source address must be **http://prometheus:9090**

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -187,6 +187,10 @@ docker run --name nacos-standalone -e MODE=standalone -v /path/application.prope
 
 ## Nacos + Grafana + Prometheus
 
+| 属性名称                                    | 描述                                        | 选项                                                                                                                                                                                    |
+|-----------------------------------------|-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|PROM_METRICS_ENABLE                        | 暴露 Nacos 所有监控指标数据 |默认 : false            |
+
 使用参考：[Nacos monitor-guide](https://nacos.io/zh-cn/docs/monitor-guide.html)
 
 **Note**:  当使用Grafana创建数据源的时候地址必须是: **http://prometheus:9090**

--- a/build/bin/docker-startup.sh
+++ b/build/bin/docker-startup.sh
@@ -73,6 +73,11 @@ if [[ ! -z "${IGNORED_INTERFACES}" ]]; then
   JAVA_OPT="${JAVA_OPT} -Dnacos.inetutils.ignored-interfaces=${IGNORED_INTERFACES}"
 fi
 
+### set Metrics for prometheus
+if [[ "${PROM_METRICS_ENABLE}" == "true" ]]; then
+  JAVA_OPT="${JAVA_OPT} -Dmanagement.endpoints.web.exposure.include=*"
+fi
+
 ### If turn on auth system:
 if [[ ! -z "${NACOS_AUTH_ENABLE}" ]]; then
   JAVA_OPT="${JAVA_OPT} -Dnacos.core.auth.enabled=${NACOS_AUTH_ENABLE}"


### PR DESCRIPTION
nacos version： all
添加prometheus metrics 变量启动的原因：
  在快速构建 Nacos 环境时，需要将 application.properties 文件从 image 中复制出来，并添加监控指标暴露，然后按照 configmap 将其挂载进去。这种做法增加了快速上手的复杂性。

之前还使用过下面的这种方法：
```yaml
        - name: NACOS_AUTH_ENABLE
          value: "true  -Dmanagement.endpoints.web.exposure.include=*"
```