### PR TITLE
application.properties配置文件内容与主库代码格式同步

### DIFF
--- a/build/conf/application.properties
+++ b/build/conf/application.properties
@@ -1,49 +1,268 @@
-# spring
+#
+# Copyright 1999-2021 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#*************** Spring Boot Related Configurations ***************#
+### Default web context path:
 server.servlet.contextPath=${SERVER_SERVLET_CONTEXTPATH:/nacos}
 server.contextPath=/nacos
-server.port=${NACOS_APPLICATION_PORT:8848}
-server.tomcat.accesslog.max-days=30
-server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %{User-Agent}i %{Request-Source}i
-server.tomcat.accesslog.enabled=${TOMCAT_ACCESSLOG_ENABLED:false}
+### Include message field
 server.error.include-message=ALWAYS
-# default current work dir
-server.tomcat.basedir=file:.
+### Default web server port:
+server.port=${NACOS_APPLICATION_PORT:8848}
+
+#*************** Network Related Configurations ***************#
+### If prefer hostname over ip for Nacos server addresses in cluster.conf:
+# nacos.inetutils.prefer-hostname-over-ip=false
+
+### Specify local server's IP:
+# nacos.inetutils.ip-address=
+
+
 #*************** Config Module Related Configurations ***************#
+### If use MySQL as datasource:
 ### Deprecated configuration property, it is recommended to use `spring.sql.init.platform` replaced.
-#spring.datasource.platform=${SPRING_DATASOURCE_PLATFORM:}
+# spring.datasource.platform=mysql
 spring.sql.init.platform=${SPRING_DATASOURCE_PLATFORM:}
-nacos.cmdb.dumpTaskInterval=3600
-nacos.cmdb.eventTaskInterval=10
-nacos.cmdb.labelTaskInterval=300
-nacos.cmdb.loadDataAtStart=false
+
+### Count of DB:
 db.num=${MYSQL_DATABASE_NUM:1}
-db.url.0=jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT:3306}/${MYSQL_SERVICE_DB_NAME}?${MYSQL_SERVICE_DB_PARAM:characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useSSL=false}
+
+### Connect URL of DB:
+db.url.0=jdbc:mysql://${MYSQL_SERVICE_HOST}:${MYSQL_SERVICE_PORT:3306}/${MYSQL_SERVICE_DB_NAME}?${MYSQL_SERVICE_DB_PARAM:characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useUnicode=true&useSSL=false&serverTimezone=UTC}
 db.user.0=${MYSQL_SERVICE_USER}
 db.password.0=${MYSQL_SERVICE_PASSWORD}
+
+### Connection pool configuration: hikariCP
+db.pool.config.connectionTimeout=30000
+db.pool.config.validationTimeout=10000
+db.pool.config.maximumPoolSize=20
+db.pool.config.minimumIdle=2
+
+#*************** Naming Module Related Configurations ***************#
+
+### If enable data warmup. If set to false, the server would accept request without local data preparation:
+# nacos.naming.data.warmup=true
+
+### If enable the instance auto expiration, kind like of health check of instance:
+# nacos.naming.expireInstance=true
+
+### Add in 2.0.0
+### The interval to clean empty service, unit: milliseconds.
+# nacos.naming.clean.empty-service.interval=60000
+
+### The expired time to clean empty service, unit: milliseconds.
+# nacos.naming.clean.empty-service.expired-time=60000
+
+### The interval to clean expired metadata, unit: milliseconds.
+# nacos.naming.clean.expired-metadata.interval=5000
+
+### The expired time to clean metadata, unit: milliseconds.
+# nacos.naming.clean.expired-metadata.expired-time=60000
+
+### The delay time before push task to execute from service changed, unit: milliseconds.
+# nacos.naming.push.pushTaskDelay=500
+
+### The timeout for push task execute, unit: milliseconds.
+# nacos.naming.push.pushTaskTimeout=5000
+
+### The delay time for retrying failed push task, unit: milliseconds.
+# nacos.naming.push.pushTaskRetryDelay=1000
+
+### Since 2.0.3
+### The expired time for inactive client, unit: milliseconds.
+# nacos.naming.client.expired.time=180000
+
+#*************** CMDB Module Related Configurations ***************#
+### The interval to dump external CMDB in seconds:
+# nacos.cmdb.dumpTaskInterval=3600
+
+### The interval of polling data change event in seconds:
+# nacos.cmdb.eventTaskInterval=10
+
+### The interval of loading labels in seconds:
+# nacos.cmdb.labelTaskInterval=300
+
+### If turn on data loading task:
+# nacos.cmdb.loadDataAtStart=false
+
+#***********Metrics for tomcat **************************#
+server.tomcat.mbeanregistry.enabled=true
+
+#***********Expose prometheus and health **************************#
+#management.endpoints.web.exposure.include=prometheus,health
+
+### Metrics for elastic search
+management.metrics.export.elastic.enabled=false
+#management.metrics.export.elastic.host=http://localhost:9200
+
+### Metrics for influx
+management.metrics.export.influx.enabled=false
+#management.metrics.export.influx.db=springboot
+#management.metrics.export.influx.uri=http://localhost:8086
+#management.metrics.export.influx.auto-create-db=true
+#management.metrics.export.influx.consistency=one
+#management.metrics.export.influx.compressed=true
+
+#*************** Access Log Related Configurations ***************#
+### If turn on the access log:
+server.tomcat.accesslog.enabled=${TOMCAT_ACCESSLOG_ENABLED:false}
+server.tomcat.accesslog.max-days=30
+### file name pattern, one file per hour
+server.tomcat.accesslog.rotate=true
+server.tomcat.accesslog.file-date-format=.yyyy-MM-dd-HH
+### The access log pattern:
+server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %{User-Agent}i %{Request-Source}i
+
+### The directory of access log:
+server.tomcat.basedir=file:.
+
+#*************** Access Control Related Configurations ***************#
+### If enable spring security, this option is deprecated in 1.2.0:
+#spring.security.enabled=false
+
+### The ignore urls of auth
+nacos.security.ignore.urls=/,/error,/**/*.css,/**/*.js,/**/*.html,/**/*.map,/**/*.svg,/**/*.png,/**/*.ico,/console-ui/public/**,/v1/auth/**,/v1/console/health/**,/actuator/**,/v1/console/server/**
+
 ### The auth system to use, currently only 'nacos' and 'ldap' is supported:
 nacos.core.auth.system.type=${NACOS_AUTH_SYSTEM_TYPE:nacos}
-### worked when nacos.core.auth.system.type=nacos
-### The token expiration in seconds:
-nacos.core.auth.plugin.nacos.token.expire.seconds=${NACOS_AUTH_TOKEN_EXPIRE_SECONDS:18000}
-### The default token:
-nacos.core.auth.plugin.nacos.token.secret.key=${NACOS_AUTH_TOKEN:}
+
+### If turn on auth system:
+nacos.core.auth.enabled=${NACOS_AUTH_ENABLE:false}
+
 ### Turn on/off caching of auth information. By turning on this switch, the update of auth information would have a 15 seconds delay.
-nacos.core.auth.caching.enabled=${NACOS_AUTH_CACHE_ENABLE:false}
+nacos.core.auth.caching.enabled=${NACOS_AUTH_CACHE_ENABLE:true}
+
+### Since 1.4.1, Turn on/off white auth for user-agent: nacos-server, only for upgrade from old version.
 nacos.core.auth.enable.userAgentAuthWhite=${NACOS_AUTH_USER_AGENT_AUTH_WHITE_ENABLE:false}
+
+### Since 1.4.1, worked when nacos.core.auth.enabled=true and nacos.core.auth.enable.userAgentAuthWhite=false.
+### The two properties is the white list for auth and used by identity the request from other server.
 nacos.core.auth.server.identity.key=${NACOS_AUTH_IDENTITY_KEY:}
 nacos.core.auth.server.identity.value=${NACOS_AUTH_IDENTITY_VALUE:}
-## spring security config
-### turn off security
-nacos.security.ignore.urls=${NACOS_SECURITY_IGNORE_URLS:/,/error,/**/*.css,/**/*.js,/**/*.html,/**/*.map,/**/*.svg,/**/*.png,/**/*.ico,/console-fe/public/**,/v1/auth/**,/v1/console/health/**,/actuator/**,/v1/console/server/**}
-# metrics for elastic search
-management.metrics.export.elastic.enabled=false
-management.metrics.export.influx.enabled=false
-nacos.naming.distro.taskDispatchThreadCount=10
-nacos.naming.distro.taskDispatchPeriod=200
-nacos.naming.distro.batchSyncKeyCount=1000
-nacos.naming.distro.initDataRatio=0.9
-nacos.naming.distro.syncRetryDelay=5000
-nacos.naming.data.warmup=true
+
+### worked when nacos.core.auth.system.type=nacos
+### The token expiration in seconds:
+nacos.core.auth.plugin.nacos.token.cache.enable=${NACOS_AUTH_TOKEN_CACHE_ENABLE:false}
+nacos.core.auth.plugin.nacos.token.expire.seconds=${NACOS_AUTH_TOKEN_EXPIRE_SECONDS:18000}
+### The default token (Base64 String):
+nacos.core.auth.plugin.nacos.token.secret.key=${NACOS_AUTH_TOKEN:}
+
+### worked when nacos.core.auth.system.type=ldap，{0} is Placeholder,replace login username
+#nacos.core.auth.ldap.url=ldap://localhost:389
+#nacos.core.auth.ldap.basedc=dc=example,dc=org
+#nacos.core.auth.ldap.userDn=cn=admin,${nacos.core.auth.ldap.basedc}
+#nacos.core.auth.ldap.password=admin
+#nacos.core.auth.ldap.userdn=cn={0},dc=example,dc=org
+#nacos.core.auth.ldap.filter.prefix=uid
+#nacos.core.auth.ldap.case.sensitive=true
+#nacos.core.auth.ldap.ignore.partial.result.exception=false
 
 
+#*************** Istio Related Configurations ***************#
+### If turn on the MCP server:
+nacos.istio.mcp.server.enabled=false
 
+#*************** Core Related Configurations ***************#
+
+### set the WorkerID manually
+# nacos.core.snowflake.worker-id=
+
+### Member-MetaData
+# nacos.core.member.meta.site=
+# nacos.core.member.meta.adweight=
+# nacos.core.member.meta.weight=
+
+### MemberLookup
+### Addressing pattern category, If set, the priority is highest
+# nacos.core.member.lookup.type=[file,address-server]
+## Set the cluster list with a configuration file or command-line argument
+# nacos.member.list=192.168.16.101:8847?raft_port=8807,192.168.16.101?raft_port=8808,192.168.16.101:8849?raft_port=8809
+## for AddressServerMemberLookup
+# Maximum number of retries to query the address server upon initialization
+# nacos.core.address-server.retry=5
+## Server domain name address of [address-server] mode
+# address.server.domain=jmenv.tbsite.net
+## Server port of [address-server] mode
+# address.server.port=8080
+## Request address of [address-server] mode
+# address.server.url=/nacos/serverlist
+
+#*************** JRaft Related Configurations ***************#
+
+### Sets the Raft cluster election timeout, default value is 5 second
+# nacos.core.protocol.raft.data.election_timeout_ms=5000
+### Sets the amount of time the Raft snapshot will execute periodically, default is 30 minute
+# nacos.core.protocol.raft.data.snapshot_interval_secs=30
+### raft internal worker threads
+# nacos.core.protocol.raft.data.core_thread_num=8
+### Number of threads required for raft business request processing
+# nacos.core.protocol.raft.data.cli_service_thread_num=4
+### raft linear read strategy. Safe linear reads are used by default, that is, the Leader tenure is confirmed by heartbeat
+# nacos.core.protocol.raft.data.read_index_type=ReadOnlySafe
+### rpc request timeout, default 5 seconds
+# nacos.core.protocol.raft.data.rpc_request_timeout_ms=5000
+
+#*************** Distro Related Configurations ***************#
+
+### Distro data sync delay time, when sync task delayed, task will be merged for same data key. Default 1 second.
+# nacos.core.protocol.distro.data.sync.delayMs=1000
+
+### Distro data sync timeout for one sync data, default 3 seconds.
+# nacos.core.protocol.distro.data.sync.timeoutMs=3000
+
+### Distro data sync retry delay time when sync data failed or timeout, same behavior with delayMs, default 3 seconds.
+# nacos.core.protocol.distro.data.sync.retryDelayMs=3000
+
+### Distro data verify interval time, verify synced data whether expired for a interval. Default 5 seconds.
+# nacos.core.protocol.distro.data.verify.intervalMs=5000
+
+### Distro data verify timeout for one verify, default 3 seconds.
+# nacos.core.protocol.distro.data.verify.timeoutMs=3000
+
+### Distro data load retry delay when load snapshot data failed, default 30 seconds.
+# nacos.core.protocol.distro.data.load.retryDelayMs=30000
+
+### enable to support prometheus service discovery
+#nacos.prometheus.metrics.enabled=true
+
+### Since 2.3
+#*************** Grpc Configurations ***************#
+
+## sdk grpc(between nacos server and client) configuration
+## Sets the maximum message size allowed to be received on the server.
+#nacos.remote.server.grpc.sdk.max-inbound-message-size=10485760
+
+## Sets the time(milliseconds) without read activity before sending a keepalive ping. The typical default is two hours.
+#nacos.remote.server.grpc.sdk.keep-alive-time=7200000
+
+## Sets a time(milliseconds) waiting for read activity after sending a keepalive ping. Defaults to 20 seconds.
+#nacos.remote.server.grpc.sdk.keep-alive-timeout=20000
+
+
+## Sets a time(milliseconds) that specify the most aggressive keep-alive time clients are permitted to configure. The typical default is 5 minutes
+#nacos.remote.server.grpc.sdk.permit-keep-alive-time=300000
+
+## cluster grpc(inside the nacos server) configuration
+#nacos.remote.server.grpc.cluster.max-inbound-message-size=10485760
+
+## Sets the time(milliseconds) without read activity before sending a keepalive ping. The typical default is two hours.
+#nacos.remote.server.grpc.cluster.keep-alive-time=7200000
+
+## Sets a time(milliseconds) waiting for read activity after sending a keepalive ping. Defaults to 20 seconds.
+#nacos.remote.server.grpc.cluster.keep-alive-timeout=20000
+
+## Sets a time(milliseconds) that specify the most aggressive keep-alive time clients are permitted to configure. The typical default is 5 minutes
+#nacos.remote.server.grpc.cluster.permit-keep-alive-time=300000


### PR DESCRIPTION
在整体copy  https://github.com/alibaba/nacos/blob/9069730a04d96a4f52be24331089a4f5f038ec8b/distribution/conf/application.properties 文件的基础上，将docker的环境变量替换上去；
原文件除最后的 nacos.naming.* 部分删除了，其他配置均保留了；

修改MYSQL_SERVICE_DB_PARAM变量的默认值与nacos默认配置文件同步;
修改NACOS_AUTH_CACHE_ENABLE变量默认值为true,与nacos默认配置文件同步; 

添加NACOS_AUTH_ENABLE变量,默认值为false;
添加NACOS_AUTH_TOKEN_CACHE_ENABLE变量,默认值为false;