### PR TITLE
add libstdc++ to Dockerfile dependencies

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 LABEL maintainer="pader <huangmnlove@163.com>"
 
 # 安装依赖
-RUN apk add --no-cache openjdk17-jre curl iputils ncurses vim libcurl bash
+RUN apk add --no-cache openjdk17-jre curl iputils ncurses vim libcurl bash libstdc++
 
 # 设置环境变量
 ENV MODE="cluster" \


### PR DESCRIPTION
## Problem

Caused by: java.lang.UnsatisfiedLinkError: /tmp/librocksdbjni15051557204401471544.so: Error loading shared library libstdc++.so.6: No such file or directory (needed by /tmp/librocksdbjni15051557204401471544.so)