### PR TITLE
支持通过 NACOS_CONSOLE_CONTEXTPATH 环境变量配置控制台上下文路径，默认为空

### DIFF
--- a/build/conf/application.properties
+++ b/build/conf/application.properties
@@ -194,7 +194,7 @@ server.error.include-message=ALWAYS
 ### Nacos Console Main port
 nacos.console.port=${NACOS_CONSOLE_PORT:8080}
 ### Nacos Server Web context path:
-nacos.console.contextPath=
+nacos.console.contextPath=${NACOS_CONSOLE_CONTEXTPATH:/nacos}
 
 ### Nacos Server context path, which link to nacos server `nacos.server.contextPath`, works when deployment type is `console`
 nacos.console.remote.server.context-path=${SERVER_SERVLET_CONTEXTPATH:/nacos}

--- a/build/conf/application.properties
+++ b/build/conf/application.properties
@@ -194,7 +194,7 @@ server.error.include-message=ALWAYS
 ### Nacos Console Main port
 nacos.console.port=${NACOS_CONSOLE_PORT:8080}
 ### Nacos Server Web context path:
-nacos.console.contextPath=${NACOS_CONSOLE_CONTEXTPATH:/nacos}
+nacos.console.contextPath=${NACOS_CONSOLE_CONTEXTPATH:}
 
 ### Nacos Server context path, which link to nacos server `nacos.server.contextPath`, works when deployment type is `console`
 nacos.console.remote.server.context-path=${SERVER_SERVLET_CONTEXTPATH:/nacos}


### PR DESCRIPTION
支持通过 `NACOS_CONSOLE_CONTEXTPATH` 环境变量配置控制台上下文路径，默认为空。

参考 [alibaba/nacos#13317](https://github.com/alibaba/nacos/issues/13317)