### PR TITLE
fix: Update startup option in docker-startup.sh

### DIFF
--- a/build/bin/docker-startup.sh
+++ b/build/bin/docker-startup.sh
@@ -140,7 +140,7 @@ JAVA_OPT="${JAVA_OPT} ${JAVA_OPT_EXT}"
 JAVA_OPT="${JAVA_OPT} --spring.config.additional-location=${CUSTOM_SEARCH_LOCATIONS}"
 JAVA_OPT="${JAVA_OPT} --spring.config.name=${CUSTOM_SEARCH_NAMES}"
 JAVA_OPT="${JAVA_OPT} --logging.config=${BASE_DIR}/conf/nacos-logback.xml"
-JAVA_OPT="${JAVA_OPT} --server.max-http-header-size=524288"
+JAVA_OPT="${JAVA_OPT} --server.max-http-request-header-size=524288"
 
 echo "Nacos is starting, you can docker logs your container"
 exec $JAVA ${JAVA_OPT}


### PR DESCRIPTION
`server.max-http-header-size` is deprecated and replaced with `server.max-http-request-header-size`.