### PR TITLE
fix: add --add-opens JVM options for JDK 17 in docker-startup.sh

### DIFF
--- a/build/bin/docker-startup.sh
+++ b/build/bin/docker-startup.sh
@@ -127,6 +127,9 @@ fi
 JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
 if [[ "$JAVA_MAJOR_VERSION" -ge "9" ]]; then
   JAVA_OPT="${JAVA_OPT} -Xlog:gc*:file=${BASE_DIR}/logs/nacos_gc.log:time,tags:filecount=10,filesize=102400"
+  JAVA_OPT="${JAVA_OPT} --add-opens=java.base/java.lang=ALL-UNNAMED"
+  JAVA_OPT="${JAVA_OPT} --add-opens=java.base/java.lang.reflect=ALL-UNNAMED"
+  JAVA_OPT="${JAVA_OPT} --add-opens=java.base/java.util=ALL-UNNAMED"
 else
   JAVA_OPT="${JAVA_OPT} -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8 "
   JAVA_OPT_EXT_FIX="-Djava.ext.dirs=${JAVA_HOME}/jre/lib/ext:${JAVA_HOME}/lib/ext"


### PR DESCRIPTION
## Summary
- Synced `--add-opens` JVM parameters from nacos main repo's `distribution/bin/startup.sh` into `build/bin/docker-startup.sh`
- Added three `--add-opens` options (`java.lang`, `java.lang.reflect`, `java.util`) in the `JAVA_MAJOR_VERSION >= 9` branch, placed after the GC log configuration
- Prevents `InaccessibleObjectException` caused by JDK 17 strong encapsulation when running Nacos in Docker/K8s

## Context
The nacos main repo has already added these parameters in `distribution/bin/startup.sh` for JDK 17 support, but the Docker image's startup script was not updated accordingly. Since the Dockerfile uses `openjdk17-jre`, this mismatch causes reflection-related failures at runtime.

## Test plan
- [ ] Build Docker image with the updated script and verify Nacos starts successfully on JDK 17
- [ ] Confirm the `--add-opens` flags appear in the JVM process arguments
- [ ] Verify no regression on existing functionality (standalone and cluster modes)

	🤖 Generated with [Qoder][https://qoder.com]