### PR TITLE
[ISSUE #14911] feat(docker): support mounted plugin and dependency directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Run the following command：
 | NACOS_CONSOLE_PORT                      | nacos.console.port                                                                                                                | default : `8080`                                                                                                                                                                      |
 | NACOS_CONSOLE_CONTEXTPATH               | nacos.console.contextPath                                                                                                         | default : ``                                                                                                                                                                          |
 | NACOS_DEPLOYMENT_TYPE                   | nacos.deployment.type                                                                                                             | default : `merged` support config `server` `console`                                                                                                                                  |
+| NACOS_EXT_PLUGIN_DIRS                   | Additional mounted plugin or dependency directories appended to `loader.path`                                                    | comma-separated directories, for example `/home/nacos/ext-plugins,/home/nacos/ext-libs`                                                                                              |
 
 ## Advanced configuration
 
@@ -202,10 +203,37 @@ For example:
 docker-compose -f example/custom-application-config.yaml up -d
 ```
 
+If you need to load extra plugin jars or dependency jars without rebuilding the image, mount those
+directories into the container and append them through `NACOS_EXT_PLUGIN_DIRS`.
+
+For example:
+
+```docker
+docker-compose -f example/custom-plugin-dir.yaml up -d
+```
+
+```docker
+docker run --name nacos-standalone \
+  -e MODE=standalone \
+  -e NACOS_AUTH_TOKEN=${your_nacos_auth_secret_token} \
+  -e NACOS_AUTH_IDENTITY_KEY=${your_nacos_server_identity_key} \
+  -e NACOS_AUTH_IDENTITY_VALUE=${your_nacos_server_identity_value} \
+  -e NACOS_EXT_PLUGIN_DIRS=/home/nacos/ext-plugins,/home/nacos/ext-libs \
+  -v /path/to/plugins:/home/nacos/ext-plugins \
+  -v /path/to/libs:/home/nacos/ext-libs \
+  -p 8080:8080 \
+  -p 8848:8848 \
+  -p 9848:9848 \
+  -d nacos/nacos-server:latest
+```
+
+This is useful when a plugin jar and its runtime dependency jars need to be mounted separately. For
+example, an LDAP deployment can mount the LDAP auth plugin jar in one directory and the required
+`spring-ldap-core` dependency jars in another.
+
 ## Nacos + Grafana + Prometheus
 
 Usage reference：[Nacos monitor-guide](https://nacos.io/zh-cn/docs/monitor-guide.html)
 
 **Note**:  When Grafana creates a new data source, the data source address must be **http://prometheus:9090**
-
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -183,6 +183,7 @@ NACOS_VERSION=v3.2.1-slim
 | NACOS_CONSOLE_PORT                      | nacos.console.port                        | default : `8080`                                                                                                                                                                      |
 | NACOS_CONSOLE_CONTEXTPATH               | nacos.console.contextPath                 | default : ``                                                                                                                                                                          |
 | NACOS_DEPLOYMENT_TYPE                   | nacos.deployment.type                     | default : `merged` 支持配置 `server` `console`                                                                                                                                            |
+| NACOS_EXT_PLUGIN_DIRS                   | 追加到 `loader.path` 的外挂插件或依赖目录                 | 使用逗号分隔目录，例如 `/home/nacos/ext-plugins,/home/nacos/ext-libs`                                                                                                                             |
 
 ## 高级配置
 
@@ -197,6 +198,33 @@ Boot的`application.properties`
 ```docker
 docker run --name nacos-standalone -e MODE=standalone -v /path/application.properties:/home/nacos/conf/application.properties -p 8848:8848 -d -p 9848:9848  nacos/nacos-server:2.1.1
 ```
+
+如果你需要在不重建镜像的情况下加载额外的插件 jar 或依赖 jar，可以把这些目录挂载到容器内，
+然后通过 `NACOS_EXT_PLUGIN_DIRS` 追加到 `loader.path`。
+
+举个例子:
+
+```docker
+docker-compose -f example/custom-plugin-dir.yaml up -d
+```
+
+```docker
+docker run --name nacos-standalone \
+  -e MODE=standalone \
+  -e NACOS_AUTH_TOKEN=${your_nacos_auth_secret_token} \
+  -e NACOS_AUTH_IDENTITY_KEY=${your_nacos_server_identity_key} \
+  -e NACOS_AUTH_IDENTITY_VALUE=${your_nacos_server_identity_value} \
+  -e NACOS_EXT_PLUGIN_DIRS=/home/nacos/ext-plugins,/home/nacos/ext-libs \
+  -v /path/to/plugins:/home/nacos/ext-plugins \
+  -v /path/to/libs:/home/nacos/ext-libs \
+  -p 8080:8080 \
+  -p 8848:8848 \
+  -p 9848:9848 \
+  -d nacos/nacos-server:latest
+```
+
+这个能力适合插件 jar 和运行时依赖 jar 需要分别挂载的场景。例如 LDAP 部署可以把 LDAP
+鉴权插件 jar 放在一个目录，把所需的 `spring-ldap-core` 依赖 jar 放在另一个目录。
 
 ## Nacos + Grafana + Prometheus
 

--- a/build/bin/docker-startup.sh
+++ b/build/bin/docker-startup.sh
@@ -16,6 +16,7 @@ export CUSTOM_SEARCH_NAMES="application"
 export CUSTOM_SEARCH_LOCATIONS=file:${BASE_DIR}/conf/
 export MEMBER_LIST="$MEMBER_LIST"
 PLUGINS_DIR="/home/nacos/plugins/peer-finder"
+DEFAULT_LOADER_PATH="${BASE_DIR}/plugins,${BASE_DIR}/plugins/health,${BASE_DIR}/plugins/cmdb,${BASE_DIR}/plugins/selector"
 function print_servers() {
    if [[ ! -d "${PLUGINS_DIR}" ]]; then
     echo "" >"$CLUSTER_CONF"
@@ -136,7 +137,12 @@ else
   JAVA_OPT="${JAVA_OPT} -Xloggc:${BASE_DIR}/logs/nacos_gc.log -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M"
 fi
 
-JAVA_OPT="${JAVA_OPT} -Dloader.path=${BASE_DIR}/plugins,${BASE_DIR}/plugins/health,${BASE_DIR}/plugins/cmdb,${BASE_DIR}/plugins/selector"
+LOADER_PATH="${DEFAULT_LOADER_PATH}"
+if [[ -n "${NACOS_EXT_PLUGIN_DIRS}" ]]; then
+  LOADER_PATH="${LOADER_PATH},${NACOS_EXT_PLUGIN_DIRS}"
+fi
+
+JAVA_OPT="${JAVA_OPT} -Dloader.path=${LOADER_PATH}"
 JAVA_OPT="${JAVA_OPT} -Dnacos.home=${BASE_DIR}"
 JAVA_OPT="${JAVA_OPT} -jar ${BASE_DIR}/target/nacos-server.jar"
 JAVA_OPT="${JAVA_OPT} ${JAVA_OPT_EXT}"

--- a/example/custom-plugin-dir.yaml
+++ b/example/custom-plugin-dir.yaml
@@ -1,0 +1,19 @@
+version: "2"
+services:
+  nacos:
+    image: nacos/nacos-server:${NACOS_VERSION}
+    container_name: nacos-standalone-plugin-dir
+    environment:
+      - MODE=standalone
+      - NACOS_AUTH_IDENTITY_KEY=serverIdentity
+      - NACOS_AUTH_IDENTITY_VALUE=security
+      - NACOS_AUTH_TOKEN=VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg=
+      - NACOS_EXT_PLUGIN_DIRS=/home/nacos/ext-plugins,/home/nacos/ext-libs
+    volumes:
+      - ./standalone-logs/:/home/nacos/logs
+      - ./plugins/:/home/nacos/ext-plugins
+      - ./libs/:/home/nacos/ext-libs
+    ports:
+      - "8080:8080"
+      - "8848:8848"
+      - "9848:9848"


### PR DESCRIPTION
Append NACOS_EXT_PLUGIN_DIRS to loader.path so operators can mount extra plugin jars and runtime dependency jars without rebuilding the Docker image.

Add compose and README examples for mounted plugin/dependency directories, including the LDAP deployment pattern.