### PR TITLE
ci: add loong64 Dockerfile and workflow support

### DIFF
--- a/.github/workflows/build&push.yaml
+++ b/.github/workflows/build&push.yaml
@@ -85,12 +85,59 @@ jobs:
           tags: |
             type=pep440,pattern=v{{version}}-slim
 
-      - name: Build and push Docker image
+      - name: Build and push Docker slim image
         uses: docker/build-push-action@v6
         with:
           context: build
           platforms: linux/amd64,linux/arm64
           file: build/Dockerfile.Slim
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.version_step.outputs.version }}
+
+  push_to_loong64_registry:
+    name: Push Docker loong64 image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Version
+        id: version_step
+        run: |
+          echo "version=NACOS_VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: nacos/nacos-server
+          flavor: |
+            latest=false
+          tags: |
+            type=pep440,pattern=v{{version}}-loong64
+
+      - name: Build and push Docker loong64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: build
+          platforms: linux/loong64
+          file: build/Dockerfile.loong64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,13 @@ jobs:
         include:
           - name: standard
             file: build/Dockerfile
+            platforms: linux/amd64,linux/arm64
           - name: slim
             file: build/Dockerfile.Slim
+            platforms: linux/amd64,linux/arm64
+          - name: loong64
+            file: build/Dockerfile.loong64
+            platforms: linux/loong64
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -24,7 +29,7 @@ jobs:
         with:
           context: build
           file: ${{ matrix.file }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms }}
           push: false
           load: false
 

--- a/build/Dockerfile.loong64
+++ b/build/Dockerfile.loong64
@@ -1,0 +1,82 @@
+FROM ghcr.io/loong64/debian:trixie-slim
+
+LABEL maintainer="徐晓伟 <xuxiaowei@xuxiaowei.com.cn>"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# 安装依赖（对应原 apk 包）
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openjdk-21-jre-headless \
+    curl \
+    iputils-ping \
+    vim \
+    libcurl4 \
+    bash \
+    ca-certificates \
+    tzdata \
+    unzip \
+    libstdc++6 \
+    && mkdir -p /opt/java \
+    && ln -sfn "$(dirname "$(dirname "$(readlink -f "$(command -v java)")")")" /opt/java/openjdk \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+ENV PATH="/root/.local/bin:${PATH}"
+
+RUN uv python install 3.10 \
+    && uv venv -p 3.10 /home/nacos/.venv
+
+RUN uv pip install -p /home/nacos/.venv/bin/python cisco-ai-skill-scanner==2.0.4
+
+ENV PATH="/home/nacos/.venv/bin:${PATH}"
+
+ENV JAVA_HOME="/opt/java/openjdk" \
+    JAVA="/opt/java/openjdk/bin/java"
+
+ENV MODE="cluster" \
+    PREFER_HOST_MODE="ip" \
+    BASE_DIR="/home/nacos" \
+    CLASSPATH=".:/home/nacos/conf:${CLASSPATH}" \
+    CLUSTER_CONF="/home/nacos/conf/cluster.conf" \
+    FUNCTION_MODE="all" \
+    NACOS_USER="nacos" \
+    JVM_XMS="1g" \
+    JVM_XMX="1g" \
+    JVM_XMN="512m" \
+    JVM_MS="128m" \
+    JVM_MMS="320m" \
+    NACOS_DEBUG="n" \
+    TOMCAT_ACCESSLOG_ENABLED="false" \
+    TIME_ZONE="Asia/Shanghai"
+
+ARG NACOS_VERSION=3.2.2
+ARG HOT_FIX_FLAG=""
+ARG SKILLS_DATA_URL="https://download.nacos.io/nacos-server-data/skills-data.zip"
+ARG AGENTSPEC_DATA_URL="https://download.nacos.io/nacos-server-data/agentspec-data.zip"
+
+WORKDIR ${BASE_DIR}
+
+RUN set -x \
+    && curl -fSL --retry 3 --output nacos-server.tar.gz "https://github.com/alibaba/nacos/releases/download/${NACOS_VERSION}${HOT_FIX_FLAG}/nacos-server-${NACOS_VERSION}.tar.gz" \
+    && tar -xzvf nacos-server.tar.gz -C /home \
+    && mkdir -p /home/nacos/data \
+    && curl -fSL --retry 3 --output /home/nacos/data/skills-data.zip "${SKILLS_DATA_URL}" \
+    && curl -fSL --retry 3 --output /home/nacos/data/agentspec-data.zip "${AGENTSPEC_DATA_URL}" \
+    && rm -rf nacos-server.tar.gz /home/nacos/bin/* /home/nacos/conf/*.properties /home/nacos/conf/*.example /home/nacos/conf/nacos-mysql.sql \
+    && ln -snf /usr/share/zoneinfo/${TIME_ZONE} /etc/localtime \
+    && echo ${TIME_ZONE} > /etc/timezone
+
+ADD bin/docker-startup.sh bin/docker-startup.sh
+ADD conf/application.properties conf/application.properties
+
+RUN mkdir -p logs \
+    && touch logs/start.out \
+    && ln -sf /dev/stdout logs/start.out \
+    && ln -sf /dev/stderr logs/start.out \
+    && chmod +x bin/docker-startup.sh
+
+EXPOSE 8848
+EXPOSE 9848 8080
+
+ENTRYPOINT ["bash", "bin/docker-startup.sh"]


### PR DESCRIPTION
Add Dockerfile.loong64 for LoongArch64 architecture based on Debian trixie-slim with openjdk-21. Add CI build matrix entry and publish job for loong64 variant.

https://github.com/nacos-group/nacos-docker/issues/510